### PR TITLE
Support rating predictions for contests with more than 10k participants.

### DIFF
--- a/src/main/java/com/wslfinc/cf/sdk/ContestProcessing.java
+++ b/src/main/java/com/wslfinc/cf/sdk/ContestProcessing.java
@@ -19,8 +19,8 @@ import static com.wslfinc.cf.sdk.Constants.MAXIMAL_CONTESTANTS;
 public class ContestProcessing {
 
   /**
-   * @param contestId Id of the contest. It is not the round number. It can be
-   *                  seen in contest URL. {@code 1 <= contestId <= MAXIMAL_CONTEST_ID}
+   * @param contestId Id of the contest. It is not the round number. It can be seen in contest URL. {@code 1 <=
+   *                  contestId <= MAXIMAL_CONTEST_ID}
    * @return contests
    */
   static Contest getContest(int contestId) {
@@ -32,8 +32,8 @@ public class ContestProcessing {
   }
 
   /**
-   * @param contestId Id of the contest. It is not the round number. It can be
-   *                  seen in contest URL. {@code 1 <= contestId <= MAXIMAL_CONTEST_ID}
+   * @param contestId Id of the contest. It is not the round number. It can be seen in contest URL. {@code 1 <=
+   *                  contestId <= MAXIMAL_CONTEST_ID}
    * @return all rows of ranklist
    */
   static List<RanklistRow> getRanklistRows(int contestId) {
@@ -41,14 +41,15 @@ public class ContestProcessing {
     Object problems = new Object();
     List<RanklistRow> rows = new ArrayList<>();
     getContestStanding(contestId, 1, MAXIMAL_CONTESTANTS, false, contest, problems, rows);
+    getContestStanding(contestId, MAXIMAL_CONTESTANTS + 1, MAXIMAL_CONTESTANTS, false, contest, problems, rows);
     return rows;
   }
 
   /**
    * Check has contest finished or not?
    *
-   * @param contestId Id of the contest. It is not the round number. It can be
-   *                  seen in contest URL. {@code 1 <= contestId <= MAXIMAL_CONTEST_ID}
+   * @param contestId Id of the contest. It is not the round number. It can be seen in contest URL. {@code 1 <=
+   *                  contestId <= MAXIMAL_CONTEST_ID}
    * @return true if contest finished
    */
   static boolean isFinished(int contestId) {
@@ -61,8 +62,7 @@ public class ContestProcessing {
    *
    * @param maxId maximal contestId
    * @param gym   true if include gym contests
-   * @return Sorted by start time list of contests with id in range
-   * [1..{@code maxId}]
+   * @return Sorted by start time list of contests with id in range [1..{@code maxId}]
    */
   public static List<Contest> getFinishedContests(int maxId, boolean gym) {
     ArrayList<Contest> contests = (ArrayList<Contest>) API.getContestsList(gym);
@@ -95,8 +95,7 @@ public class ContestProcessing {
     return result;
   }
 
-  private static ConcurrentHashMap<Integer, Boolean> educational
-    = new ConcurrentHashMap<>();
+  private static ConcurrentHashMap<Integer, Boolean> educational = new ConcurrentHashMap<>();
 
   public static boolean isEducational(int contestId) {
     if (educational.containsKey(contestId)) {

--- a/src/main/java/com/wslfinc/cf/sdk/ContestantProcessing.java
+++ b/src/main/java/com/wslfinc/cf/sdk/ContestantProcessing.java
@@ -47,27 +47,27 @@ public class ContestantProcessing {
    */
   @Deprecated
   static List<Contestant> getActiveContestants(int contestId) {
-    List<Contestant> registredContestants = getAllContestants(contestId);
+    List<Contestant> registeredContestants = getAllContestants(contestId);
     List<RanklistRow> rows = getRanklistRows(contestId);
 
     Map<String, Integer> prevRating = new HashMap<>();
-    for (Contestant contestant : registredContestants) {
+    for (Contestant contestant : registeredContestants) {
       prevRating.put(contestant.getHandle(), contestant.getPrevRating());
     }
 
-    return getActiveContestants(registredContestants, prevRating, rows);
+    return getActiveContestants(registeredContestants, prevRating, rows);
   }
 
   static ArrayList<Team> getActiveTeams(int contestId) {
-    List<Contestant> registredContestants = getAllContestants(contestId);
+    List<Contestant> registeredContestants = getAllContestants(contestId);
     List<RanklistRow> rows = getRanklistRows(contestId);
 
     Map<String, Integer> prevRating = new HashMap<>();
-    for (Contestant contestant : registredContestants) {
+    for (Contestant contestant : registeredContestants) {
       prevRating.put(contestant.getHandle(), contestant.getPrevRating());
     }
 
-    return getActiveTeams(contestId, registredContestants, prevRating, rows);
+    return getActiveTeams(contestId, registeredContestants, prevRating, rows);
   }
 
   @Deprecated

--- a/src/main/java/com/wslfinc/cf/sdk/api/ContestAPI.java
+++ b/src/main/java/com/wslfinc/cf/sdk/api/ContestAPI.java
@@ -98,7 +98,6 @@ class ContestAPI {
         problems = result.getJSONArray("problems");
         JSONArray array = result.getJSONArray("rows");
 
-        rows.clear();
         for (Object item : array) {
           rows.add(new RanklistRow((JSONObject) item));
         }


### PR DESCRIPTION
Codeforces API returns contest standing for no more than 10k participants. So, CF-Predictor will do 2 requests to Codeforces to load up to 20k results.
It's a hotfix. It has a couple issues:
1. Requests to the Codeforces API aren't simultaneous, so standings can change between requests. In this case, some contestants might be missed or duplicated.
2. 20k is a new hard limit of participants.